### PR TITLE
Update 2024-05-28-vancouver-socratic-24.md

### DIFF
--- a/_posts/2024-05-28-vancouver-socratic-24.md
+++ b/_posts/2024-05-28-vancouver-socratic-24.md
@@ -103,7 +103,7 @@ Joule
 - [Silentium, a progressive web app for silent Bitcoin payments](https://app.silentium.dev/)
 
 ## Events and Podcasts
-
+- [Collision 2024, July 17-20](https://collisionconf.com/media)
 
 
 ## Miscellaneous


### PR DESCRIPTION
Collision Tech Conference 2024, added for media pass coverage.